### PR TITLE
feat: add protocol error detection to devproxy

### DIFF
--- a/src/WebpackTools/middlewares/DevProxy.js
+++ b/src/WebpackTools/middlewares/DevProxy.js
@@ -1,4 +1,38 @@
+/**
+ * Proxies all requests not served by Webpack in-memory bundling back
+ * to the underlying store.
+ *
+ * Tries to detect a case where the target URL is misconfigured and the
+ * store tries to redirect to http or https.
+ */
 const proxy = require('http-proxy-middleware');
+const { format, URL } = require('url');
+
+const RedirectCodes = [201, 301, 302, 307, 308];
+const findRedirect = message =>
+    RedirectCodes.includes(message.statusCode) && message.headers.location;
+
+const detectProtocolChange = (target, redirected) => {
+    const backend = new URL(target);
+    const { host, protocol } = new URL(redirected);
+    if (backend.host === host && backend.protocol !== protocol) {
+        if (backend.protocol === 'https:' && protocol === 'http:') {
+            throw Error(
+                `pwa-buildpack: Backend domain is configured to ${target}, but redirected to unsecure HTTP. Please configure backend server to use SSL.`
+            );
+        } else if (backend.protocol === 'http:' && protocol === 'https:') {
+            throw Error(
+                `pwa-buildpack: Backend domain is configured to ${target}, but redirected to secure HTTPS. Please change configuration to point to secure backend domain: ${format(
+                    Object.assign(backend, { protocol: 'https:' })
+                )}.`
+            );
+        } else {
+            throw Error(
+                `pwa-buildpack: Backend domain redirected to unknown protocol: ${redirected}`
+            );
+        }
+    }
+};
 
 module.exports = function createDevProxy(
     target,
@@ -7,9 +41,17 @@ module.exports = function createDevProxy(
 ) {
     const noDot = passthru.map(x => x.replace(/^\./, ''));
     return proxy(['**', `!**/*.{${noDot.join(',')}}`], {
+        onProxyRes(proxyRes) {
+            const redirected = findRedirect(proxyRes);
+            if (redirected) {
+                detectProtocolChange(target, redirected);
+            }
+        },
         target,
         logLevel,
         secure: false,
-        changeOrigin: true
+        changeOrigin: true,
+        autoRewrite: true,
+        cookieDomainRewrite: '' // remove any absolute domain on cookies
     });
 };

--- a/src/WebpackTools/middlewares/__tests__/DevProxy.spec.js
+++ b/src/WebpackTools/middlewares/__tests__/DevProxy.spec.js
@@ -14,12 +14,12 @@ test('proxies requests based on target and extension', () => {
     );
     expect(proxyMiddleware).toHaveBeenCalledWith(
         ['**', '!**/*.{js,woah,js.map}'],
-        {
+        expect.objectContaining({
             target: 'https://shampoo.infrequently',
             logLevel: 'warn',
             secure: false,
             changeOrigin: true
-        }
+        })
     );
 });
 


### PR DESCRIPTION
Currently, the DevServer will redirect to the backend domain if the backend domain tries to redirect a request to `/`. This is a problem when you've accidentally configured your dev setup for the unsecure `http` version of your backend, and your backend wants to redirect to `https` -- or vice versa. This helps the DevProxy detect that common config mistake.