### PR TITLE
Disable buggy OriginSubstitution by default

### DIFF
--- a/docs/PWADevServer.md
+++ b/docs/PWADevServer.md
@@ -93,6 +93,9 @@ configuration.
   - `assets`: Directory for other public static assets.
 - `serviceWorkerFileName: string`: **Required.** The name of the ServiceWorker
    file this theme creates, e.g. `'sw.js'`.
+- `changeOrigin: boolean`: ⚠️ **(experimental)** Try to parse any HTML responses
+   from the proxied Magento backend, and replace its domain name with the
+   dev server domain name. Default `false`.
 - `middleware: function`: A function which receives the Express `app` as its
    argument. Runs before the app is configured otherwise (in the `before` step),
    so you can use this to add custom middleware.

--- a/src/WebpackTools/PWADevServer.js
+++ b/src/WebpackTools/PWADevServer.js
@@ -146,13 +146,15 @@ const PWADevServer = {
                 Object.assign({}, devHost, { pathname: config.publicPath })
             ),
             before(app) {
-                // replace origins in links in returned html
-                app.use(
-                    middlewares.originSubstitution(
-                        new url.URL(config.backendDomain),
-                        devHost
-                    )
-                );
+                if (config.changeOrigin) {
+                    // replace origins in links in returned html
+                    app.use(
+                        middlewares.originSubstitution(
+                            new url.URL(config.backendDomain),
+                            devHost
+                        )
+                    );
+                }
                 // proxy to backend
                 app.use(
                     middlewares.devProxy(config.backendDomain, {

--- a/src/WebpackTools/middlewares/OriginSubstitution.js
+++ b/src/WebpackTools/middlewares/OriginSubstitution.js
@@ -9,6 +9,8 @@
  *
  * For Magento 2 specifically, This is a stopgap until we can hack Framework to
  * have branch logic in asset URL resolvers.
+ *
+ * EXPERIMENTAL -- not ready for prime time
  */
 const debug = require('../../util/debug').makeFileLogger(__filename);
 const url = require('url');
@@ -36,6 +38,7 @@ module.exports = function createOriginSubstitutionMiddleware(
     const tagsToReplaceOrigin = ['style'].map(attr => ({
         query: attr,
         func(node) {
+            debug('tag', attr, node);
             const stream = node.createStream();
             stream
                 .pipe(


### PR DESCRIPTION
The OriginSubstitution middleware for replacing domain names:

 - Heavy (streams, parsing)
 - Buggy (I started to get random stream breakage with bad stacktraces)
 - Possibly unnecessary (if we aren't using any layout-generated resources, there are no absolute URLs to replace!)

Disabling by default and putting it behind a `changeOrigin` flag.