### PR TITLE
suggested edit for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ which reads an ini-formatted file to set the environment.
    ```js
    const webpack = require('webpack');
    const {
-       Webpack: {
+       WebpackTools: {
            MagentoRootComponentsPlugin,
            ServiceWorkerPlugin,
            MagentoResolver,


### PR DESCRIPTION
followed these instructions and  got the following error...
```
webpack.config.js:11
} = require('@magento/pwa-buildpack');
    ^

TypeError: Cannot match against 'undefined' or 'null'.
```

When I changed 
```
const {
       Webpack: {
```
To...
```
const {
       WebpackTools: {
```
above error went away after change.  I'm not clear as to why this fixed it but found this was the syntax used [here](https://github.com/magento-research/venia-pwa-concept/blob/master/theme-frontend-venia/webpack.config.js)

following on from this, I got new error, but I've already reported it here...
https://github.com/magento-research/venia-pwa-concept/issues/51