### PR TITLE
fix(util): fix run-as-root await rm bug

### DIFF
--- a/src/util/__tests__/run-as-root.spec.js
+++ b/src/util/__tests__/run-as-root.spec.js
@@ -4,6 +4,8 @@ jest.mock('sudo-prompt');
 const sudoPrompt = require('sudo-prompt');
 const path = require('path');
 const { writeFile, unlink } = require('../promisified/fs');
+const fs = require.requireActual('../promisified/fs');
+const { exec } = require('../promisified/child_process');
 
 const implDir = path.resolve(__dirname, '..');
 
@@ -23,22 +25,53 @@ test('serializes and writes a script to fs', async () => {
     expect(eval(writeFile.mock.calls[0][1])).toBe(23);
 });
 
+test('runs visual sudoPrompt with title and icon', async () => {
+    sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
+        setImmediate(() => cb(null, '', ''))
+    );
+    await runAsRoot((x, y) => x + y * 5, 3, 4);
+    expect(sudoPrompt.exec).toHaveBeenCalledWith(
+        expect.stringContaining('node'),
+        expect.objectContaining({
+            name: 'Magento PWA Studio',
+            icns: expect.any(String)
+        }),
+        expect.any(Function)
+    );
+    const { icns } = sudoPrompt.exec.mock.calls[0][1];
+    await expect(fs.stat(icns)).resolves.toBeTruthy();
+});
+
 test('reports errors informatively', async () => {
     sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
         setImmediate(() =>
-            cb(new Error('the error message'), 'standard error', 'standard out')
+            cb(
+                new Error('object error message'),
+                'standard error',
+                'standard out'
+            )
         )
     );
     await expect(runAsRoot(x => x)).rejects.toThrowError(
-        /the error message\s+standard out\s+standard error/m
+        /object error message\s+standard out\s+standard error/m
+    );
+    sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
+        setImmediate(() =>
+            cb('raw error message', 'standard error', 'standard out')
+        )
+    );
+    await expect(runAsRoot(x => x)).rejects.toThrowError(
+        /raw error message\s+standard out\s+standard error/m
     );
 });
 
 test('cleans up temp file on success or failure', async () => {
     sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
-        setImmediate(() => cb(null, '', ''))
+        exec(cmd).then(res => cb(null, res.stdout, res.stderr), cb)
     );
-    await runAsRoot(() => true);
+    writeFile.mockImplementation(fs.writeFile);
+    unlink.mockImplementation(fs.unlink);
+    await runAsRoot(() => console.log('squanch'));
     expect(writeFile).toHaveBeenCalledTimes(1);
     expect(unlink).toHaveBeenCalledTimes(1);
     sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>

--- a/src/util/__tests__/run-as-root.spec.js
+++ b/src/util/__tests__/run-as-root.spec.js
@@ -1,34 +1,37 @@
-jest.mock('../promisified/fs');
 jest.mock('sudo-prompt');
 
 const sudoPrompt = require('sudo-prompt');
 const path = require('path');
-const { writeFile, unlink } = require('../promisified/fs');
-const fs = require.requireActual('../promisified/fs');
+const fs = require('../promisified/fs');
 const { exec } = require('../promisified/child_process');
 
 const implDir = path.resolve(__dirname, '..');
 
 const runAsRoot = require('../run-as-root');
 
+afterEach(jest.restoreAllMocks);
 test('serializes and writes a script to fs', async () => {
     sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
         setImmediate(() => cb(null, '', ''))
     );
+    jest.spyOn(fs, 'writeFile').mockResolvedValue();
+    jest.spyOn(fs, 'unlink').mockResolvedValue();
     await runAsRoot((x, y) => x + y * 5, 3, 4);
-    expect(writeFile).toHaveBeenCalledWith(
+    expect(fs.writeFile).toHaveBeenCalledWith(
         expect.any(String),
         '((x, y) => x + y * 5)(...[3,4])',
         'utf8'
     );
-    expect(path.dirname(writeFile.mock.calls[0][0])).toBe(implDir);
-    expect(eval(writeFile.mock.calls[0][1])).toBe(23);
+    expect(path.dirname(fs.writeFile.mock.calls[0][0])).toBe(implDir);
+    expect(eval(fs.writeFile.mock.calls[0][1])).toBe(23);
 });
 
 test('runs visual sudoPrompt with title and icon', async () => {
     sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
         setImmediate(() => cb(null, '', ''))
     );
+    jest.spyOn(fs, 'writeFile').mockResolvedValue();
+    jest.spyOn(fs, 'unlink').mockResolvedValue();
     await runAsRoot((x, y) => x + y * 5, 3, 4);
     expect(sudoPrompt.exec).toHaveBeenCalledWith(
         expect.stringContaining('node'),
@@ -52,6 +55,8 @@ test('reports errors informatively', async () => {
             )
         )
     );
+    jest.spyOn(fs, 'writeFile').mockResolvedValue();
+    jest.spyOn(fs, 'unlink').mockResolvedValue();
     await expect(runAsRoot(x => x)).rejects.toThrowError(
         /object error message\s+standard out\s+standard error/m
     );
@@ -69,20 +74,20 @@ test('cleans up temp file on success or failure', async () => {
     sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
         exec(cmd).then(res => cb(null, res.stdout, res.stderr), cb)
     );
-    writeFile.mockImplementation(fs.writeFile);
-    unlink.mockImplementation(fs.unlink);
-    await runAsRoot(() => console.log('squanch'));
-    expect(writeFile).toHaveBeenCalledTimes(1);
-    expect(unlink).toHaveBeenCalledTimes(1);
+    jest.spyOn(fs, 'writeFile');
+    jest.spyOn(fs, 'unlink');
+    await expect(runAsRoot(() => console.log('foo'))).resolves.toMatch('foo');
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
     sudoPrompt.exec.mockImplementationOnce((cmd, opts, cb) =>
         setImmediate(() =>
             cb(new Error('the error message'), 'standard error', 'standard out')
         )
     );
     await expect(runAsRoot(x => x)).rejects.toThrowError();
-    expect(writeFile).toHaveBeenCalledTimes(2);
-    expect(unlink).toHaveBeenCalledTimes(2);
-    writeFile.mock.calls.forEach((call, index) =>
-        expect(call[0]).toEqual(unlink.mock.calls[index][0])
+    expect(fs.writeFile).toHaveBeenCalledTimes(2);
+    expect(fs.unlink).toHaveBeenCalledTimes(2);
+    fs.writeFile.mock.calls.forEach((call, index) =>
+        expect(call[0]).toEqual(fs.unlink.mock.calls[index][0])
     );
 });

--- a/src/util/run-as-root.js
+++ b/src/util/run-as-root.js
@@ -5,7 +5,7 @@
 
 const debug = require('./debug').makeFileLogger(__filename);
 const path = require('path');
-const { writeFile, unlink } = require('./promisified/fs');
+const fs = require('./promisified/fs');
 const sudoPrompt = require('sudo-prompt');
 const { join } = require('path');
 const tmp = () =>
@@ -28,13 +28,18 @@ const sudoPromptToRunShell = async cmd =>
         sudoPrompt.exec(cmd, opts, (error, stdout, stderr) => {
             debug(`sudo ${cmd} returned`, { error, stdout, stderr });
             if (error) {
-                return reject(
-                    new Error(
-                        [error.message || error, stderr, stdout]
-                            .filter(x => !!x)
-                            .join('\n\n')
-                    )
-                );
+                const isTruthy = x => x;
+                // the below trick displays all non-empty values
+                // without a bunch of extra newlines
+                const fullOutputForError = [
+                    error.message || error,
+                    stderr,
+                    stdout
+                ]
+                    .filter(isTruthy)
+                    .join('\n\n');
+
+                return reject(new Error(fullOutputForError));
             }
             return resolve(stdout);
         });
@@ -80,11 +85,11 @@ module.exports = async (fn, ...args) => {
     const impl = fn.toString();
     const scriptLoc = tmp();
     const invoked = `(${impl})(...${JSON.stringify(args)})`;
-    await writeFile(scriptLoc, invoked, 'utf8');
+    await fs.writeFile(scriptLoc, invoked, 'utf8');
     debug(`elevating privileges for ${impl}`);
     try {
         return await sudoPromptToRunShell(`${process.argv[0]} ${scriptLoc}`);
     } finally {
-        await unlink(scriptLoc);
+        await fs.unlink(scriptLoc);
     }
 };

--- a/src/util/run-as-root.js
+++ b/src/util/run-as-root.js
@@ -28,15 +28,15 @@ const sudoPromptToRunShell = async cmd =>
         sudoPrompt.exec(cmd, opts, (error, stdout, stderr) => {
             debug(`sudo ${cmd} returned`, { error, stdout, stderr });
             if (error) {
-                const isTruthy = x => x;
                 // the below trick displays all non-empty values
                 // without a bunch of extra newlines
+                const identity = x => x;
                 const fullOutputForError = [
                     error.message || error,
                     stderr,
                     stdout
                 ]
-                    .filter(isTruthy)
+                    .filter(identity)
                     .join('\n\n');
 
                 return reject(new Error(fullOutputForError));


### PR DESCRIPTION
 - Fix my mistake where I both ran `rm` in the shell and ran `unlink` in
 JS.
 - Properly await result of sudoPrompt.
 - Add tests against real FS to ensure that file cleanup is handled
 well.

Should fix magento-research/venia-pwa-concept#51 when merged and released.