### PR TITLE
fix(DevProxy): put proxy after other middlewares

### DIFF
--- a/docs/PWADevServer.md
+++ b/docs/PWADevServer.md
@@ -96,6 +96,3 @@ configuration.
 - `changeOrigin: boolean`: ⚠️ **(experimental)** Try to parse any HTML responses
    from the proxied Magento backend, and replace its domain name with the
    dev server domain name. Default `false`.
-- `middleware: function`: A function which receives the Express `app` as its
-   argument. Runs before the app is configured otherwise (in the `before` step),
-   so you can use this to add custom middleware.

--- a/package-lock.json
+++ b/package-lock.json
@@ -466,6 +466,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1728,6 +1734,20 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1745,6 +1765,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -2227,6 +2253,21 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-is": {
@@ -4006,6 +4047,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-port": {
@@ -6582,6 +6629,23 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "nock": {
+      "version": "9.2.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.2.5.tgz",
+      "integrity": "sha512-ciCpyEq72Ws6/yhdayDfd0mAb3eQ7/533xKmFlBQZ5CDwrL0/bddtSicfL7R07oyvPAuegQrR+9ctrlPEp0EjQ==",
+      "dev": true,
+      "requires": {
+        "chai": "4.1.2",
+        "debug": "3.1.0",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "propagate": "1.0.0",
+        "qs": "6.5.1",
+        "semver": "5.5.0"
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -7162,6 +7226,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -7356,6 +7426,12 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -9253,6 +9329,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jest": "^22.4.0",
     "jest-junit-reporter": "^1.1.0",
     "memory-fs": "^0.4.1",
+    "nock": "^9.2.5",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.8.1",
     "prettier-check": "^2.0.0",

--- a/src/WebpackTools/PWADevServer.js
+++ b/src/WebpackTools/PWADevServer.js
@@ -155,24 +155,23 @@ const PWADevServer = {
                         )
                     );
                 }
-                // proxy to backend
-                app.use(
-                    middlewares.devProxy(config.backendDomain, {
-                        passthru: ['js', 'map', 'css', 'json', 'svg']
-                    })
-                );
                 // serviceworker root route
                 app.use(
                     middlewares.staticRootRoute(
                         join(config.paths.output, config.serviceWorkerFileName)
                     )
                 );
+            },
+            after(app) {
                 // set static server to load and serve from different paths
                 app.use(config.publicPath, express.static(config.paths.assets));
 
-                if (typeof config.middleware === 'function') {
-                    config.middleware(app);
-                }
+                // proxy to backend
+                app.use(
+                    middlewares.devProxy({
+                        target: config.backendDomain
+                    })
+                );
             }
         };
     }

--- a/src/WebpackTools/middlewares/__tests__/DevProxy.spec.js
+++ b/src/WebpackTools/middlewares/__tests__/DevProxy.spec.js
@@ -13,6 +13,11 @@ beforeAll(() => {
         logger[method] = jest.fn();
         jest.spyOn(console, method).mockImplementation();
     });
+    // We wait to require DevProxy here because DevProxy imports `http-proxy-middleware`, and
+    // `http-proxy-middleware` creates a "default logger" at module definition time--that is, when
+    // we require() it. The default logger destructures the console object, so it no longer holds
+    // a reference to `console` itself. This makes us unable to mock `console` for the
+    // `http-proxy-middleware` library if it loads before the mock does.
     devProxy = require('../DevProxy');
 });
 

--- a/src/WebpackTools/middlewares/__tests__/DevProxy.spec.js
+++ b/src/WebpackTools/middlewares/__tests__/DevProxy.spec.js
@@ -1,34 +1,146 @@
-jest.mock('http-proxy-middleware');
+let devProxy;
+const request = require('supertest');
+const nock = require('nock');
+const express = require('express');
 
-const proxyMiddleware = require('http-proxy-middleware');
+const TARGET = 'https://proxytarget.test';
+const TARGET_UNSECURE = 'http://proxytarget.test';
+const logger = {};
+const logMethods = ['log', 'debug', 'info', 'warn', 'error'];
 
-const devProxy = require('../DevProxy');
+beforeAll(() => {
+    logMethods.forEach(method => {
+        logger[method] = jest.fn();
+        jest.spyOn(console, method).mockImplementation();
+    });
+    devProxy = require('../DevProxy');
+});
 
-test('proxies requests based on target and extension', () => {
-    devProxy(
-        'https://shampoo.infrequently',
-        {
-            passthru: ['js', 'woah', '.js.map']
-        },
-        'warn'
-    );
-    expect(proxyMiddleware).toHaveBeenCalledWith(
-        ['**', '!**/*.{js,woah,js.map}'],
-        expect.objectContaining({
-            target: 'https://shampoo.infrequently',
-            logLevel: 'warn',
-            secure: false,
-            changeOrigin: true
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+afterAll(() => {
+    logMethods.forEach(method => {
+        console[method].mockRestore();
+    });
+    nock.restore();
+});
+
+test('logs to custom logger', async () => {
+    nock(TARGET)
+        .get('/will-log')
+        .reply(200, 'Hello world!');
+
+    const appWithCustomLogger = express();
+    appWithCustomLogger.use(
+        devProxy({
+            logger,
+            target: TARGET
         })
+    );
+
+    await request(appWithCustomLogger).get('/will-log');
+
+    expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('will-log')
     );
 });
 
-test('default loglevel is debug', () => {
-    devProxy('https://condition.constantly', {
-        passthru: ['js', 'woah', '.js.map']
-    });
-    expect(proxyMiddleware.mock.calls[0][1]).toHaveProperty(
-        'logLevel',
-        'debug'
+test('logs to console by default', async () => {
+    nock(TARGET)
+        .get('/will-log')
+        .reply(200, 'Hello world!');
+    const app = express();
+    app.use(
+        devProxy({
+            target: TARGET
+        })
     );
+
+    await request(app).get('/will-log');
+
+    expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('will-log')
+    );
+
+    console.log.mockRestore();
+});
+
+test('handles redirects silently when origin is same', async () => {
+    nock(TARGET)
+        .get('/will-proxy-to-self')
+        .reply(301, '', {
+            Location: TARGET + '/redirected-to'
+        });
+
+    const app = express();
+    app.use(
+        devProxy({
+            logger,
+            target: TARGET
+        })
+    );
+
+    await expect(
+        request(app)
+            .get('/will-proxy-to-self')
+            .expect(301)
+            .expect('location', /redirected\-to/)
+    ).resolves.toBeTruthy();
+});
+
+test('errors informatively on redirect with protocol change', async () => {
+    nock(TARGET_UNSECURE)
+        .get('/will-proxy-to-secure')
+        .reply(301, '', {
+            Location: TARGET + '/will-proxy-to-secure'
+        });
+
+    const app = express();
+    app.use(
+        devProxy({
+            logger,
+            target: TARGET_UNSECURE
+        })
+    );
+
+    await expect(
+        request(app).get('/will-proxy-to-secure')
+    ).resolves.toMatchObject({
+        status: 500,
+        text: expect.stringContaining('redirected to secure HTTPS')
+    });
+
+    nock(TARGET)
+        .get('/will-proxy-to-unsecure')
+        .reply(301, '', {
+            Location: TARGET_UNSECURE + '/will-proxy-to-unsecure'
+        })
+        .get('/will-proxy-to-nowhere')
+        .reply(302, '', {
+            Location: 'badprotocol' + TARGET + '/will-proxy-to-nowhere'
+        });
+
+    const secureApp = express();
+    secureApp.use(
+        devProxy({
+            logger,
+            target: TARGET
+        })
+    );
+
+    await expect(
+        request(secureApp).get('/will-proxy-to-unsecure')
+    ).resolves.toMatchObject({
+        status: 500,
+        text: expect.stringContaining('redirected to unsecure HTTP')
+    });
+
+    await expect(
+        request(secureApp).get('/will-proxy-to-nowhere')
+    ).resolves.toMatchObject({
+        status: 500,
+        text: expect.stringContaining('redirected to unknown protocol')
+    });
 });


### PR DESCRIPTION
Modify PWADevServer to add the backend proxy in the `after()` block, not
the `before()` block. This allows `webpack-dev-middleware` to handle any
requests that it can handle, before the proxy can intercept them. This
is simple, doesn't require any filtering or regex matching, and does
exactly what the dev wants!

Along the way:
 - [x] Improved DevProxy tests, which were too implementation-bound.
 - [x] Improved error handling pathway for DevProxy protocol change detection, since it was breaking the new tests.
 - [x] Refactored DevProxy config to be easier on the eyes.
 - [x] Removed the `middleware` option from PWADevServer config, which is too crufty and unclear now that we're using `before()` and `after()`.

Fixes #32.